### PR TITLE
Fixing "undefined" bug

### DIFF
--- a/preprocessing/preprocess_flex.js
+++ b/preprocessing/preprocess_flex.js
@@ -120,7 +120,8 @@ function concatWords(sentenceTokens) {
       sentenceText += " ";
     }
     maybeAddSpace = (typedToken.type !== "start");
-    sentenceText += typedToken["value"];
+    // If the word token's value is undefined, skip this word.
+    sentenceText += typedToken["value"] || "";
   }
   return sentenceText;
 }


### PR DESCRIPTION
This PR aims to fix the bug where "undefined" shows up in texts on LingView, as reported at #40 .

The "undefined" seems to show up at places where the FLEx file has 
```
<word>
                <item type="punct" lang="con-Latn-EC-x-dureno">
</item>
              </word>
```
as a word entry. This word entry doesn't have any values. The normal punctuations have the corresponding values, such as a "," symbol in its word entry.

So I tried to fix this bug by changing the concatWords function in preprocess_flex.js file. If a word token's value is undefined, then the function essentially skip that word. In this way, the "undefined" word shouldn't show up anymore, as shown in this example image: 

![Screen Shot 2020-09-27 at 22 00 03](https://user-images.githubusercontent.com/46336328/94383017-d5045b80-010c-11eb-9174-307ea4705cf8.png)
