### PR TITLE
Fix unstable scrolling bug

### DIFF
--- a/jsx/App/Stories/Story/lib/txt_sync.js
+++ b/jsx/App/Stories/Story/lib/txt_sync.js
@@ -26,9 +26,11 @@ export function setupTextSync() {
     function scrollIntoViewIfNeeded(target) {
         var rect = target.getBoundingClientRect();
         if (rect.bottom > window.innerHeight) {
+            console.log("first");
             target.scrollIntoView(false);
         }
         if (rect.top < 0) {
+            console.log("second");
             target.scrollIntoView();
         } 
     }
@@ -72,13 +74,11 @@ export function setupTextSync() {
         }
     });
 
-    /* For files without AV, change the selected sentence's color and scroll to it. */
+    /* For files without AV, change the selected sentence's color and update query URL. */
     function updateForUntimedFile(sentId) {
         for (var i = 0; i < ts_tag_array.length; i++) {
             // sentence id starts with 1
             if (i+1 == sentId) {
-                ts_tag_array[i].setAttribute("id", "current");
-                scrollIntoViewIfNeeded($("#current")[0]);
                 highlightSentence(i);
             } else {
                 unHighlightSentence(i);
@@ -130,6 +130,8 @@ export function setupTextSync() {
                 setMediaCurrentTime(sentenceTimestampId + 1);
             } else {
                 updateForUntimedFile(sentenceTimestampId);
+                ts_tag_array[sentenceTimestampId].setAttribute("id", "current");
+                scrollIntoViewIfNeeded($("#current")[0]);
             } 
         }
     });

--- a/jsx/App/Stories/Story/lib/txt_sync.js
+++ b/jsx/App/Stories/Story/lib/txt_sync.js
@@ -26,11 +26,9 @@ export function setupTextSync() {
     function scrollIntoViewIfNeeded(target) {
         var rect = target.getBoundingClientRect();
         if (rect.bottom > window.innerHeight) {
-            console.log("first");
             target.scrollIntoView(false);
         }
         if (rect.top < 0) {
-            console.log("second");
             target.scrollIntoView();
         } 
     }


### PR DESCRIPTION
The previous PR contains a bug where clicking on the sentence id of a non-AV file exhibits strange scrolling behavior. I changed it so that clicking on a sentence id does not scroll and only highlights the sentence. Only changing the index in the URL will trigger the page to scroll to the sentence. 