### PR TITLE
Refactor tier registry

### DIFF
--- a/preprocessing/flex/flex_tier_names.js
+++ b/preprocessing/flex/flex_tier_names.js
@@ -1,4 +1,7 @@
-/* functions for naming Flex tiers */
+/* 
+Functions for naming Flex tiers. 
+Edit these if you want tier names to display differently on your LingView site. 
+*/
 
 const isoDict = require('./iso_dict.json');
 
@@ -12,7 +15,7 @@ function decodeType(type) {
         case "cf": return "morpheme (citation form)";
         case "gls": return "morpheme gloss";
         case "msa": return "part of speech";
-        case "variantTypes": return "variant type"; // indicates when a morpheme is a spelling variant, free variant, etc.
+        case "variantTypes": return "type of variant"; // indicates when a morpheme is a spelling variant, free variant, etc.
         case "hn": return "homophone number"; // indicates which of multiple look-alike morphemes it is
     default: return type;
     }
@@ -28,6 +31,10 @@ function decodeType(type) {
       return "Glosa de morfema";
     case "msa":
       return "Parte del habla";
+    case "variantTypes":
+      return "Clase de variedad";
+    case "hn":
+      return "Número de homòfono";
     case "words":
       return "Palabra";
     case "free":

--- a/preprocessing/flex/flex_tier_names.js
+++ b/preprocessing/flex/flex_tier_names.js
@@ -1,6 +1,6 @@
 /* functions for naming Flex tiers */
 
-var isoDict = require('./iso_dict.json');
+const isoDict = require('./iso_dict.json');
 
 function isIgnored(type) {
   // Omit these tier types from the website, because they're ugly and mostly useless.

--- a/preprocessing/flex/flex_tier_names.js
+++ b/preprocessing/flex/flex_tier_names.js
@@ -2,16 +2,6 @@
 
 const isoDict = require('./iso_dict.json');
 
-function isIgnored(type) {
-  // Omit these tier types from the website, because they're ugly and mostly useless.
-  return (
-      type === "variantTypes" || // variantTypes indicates when a morpheme is a spelling variant, free variant, etc.
-      type === "hn" || // hn, "homophone number", indicates which of multiple look-alike morphemes it is.
-      type === "glsAppend" ||
-      type === "msa" // msa is the part of speech
-  );
-}
-
 // Must return a different string for each tier type in the corpus
 // so that tier names can be guaranteed to be unique.
 function decodeType(type) {
@@ -20,8 +10,10 @@ function decodeType(type) {
     switch(type) {
         case "txt": return "morpheme (text)";
         case "cf": return "morpheme (citation form)";
-        case "gls": return "morpheme gloss"
+        case "gls": return "morpheme gloss";
         case "msa": return "part of speech";
+        case "variantTypes": return "variant type"; // indicates when a morpheme is a spelling variant, free variant, etc.
+        case "hn": return "homophone number"; // indicates which of multiple look-alike morphemes it is
     default: return type;
     }
   */
@@ -53,7 +45,7 @@ function decodeLang(lang) {
   const lcLang = lang.toLowerCase(); // ignore capitalization when decoding
 
   // Override the usual iso-based decoding for some language codes
-  switch (lang) {
+  switch (lcLang) {
     // case "flex-language-name-here": return "desired-decoded-name-here";
     case "con-Latn-EC":
       return "A'ingae (Borman)";
@@ -87,16 +79,11 @@ function decodeLang(lang) {
   return lang;
 }
 
-// if the tier is ignored, return null; else return its name
 // Note: LingView assumes that each tier has a unique name. 
 // If getTierName returns the same name for two different tiers in your corpus,
 // some features (specifically, showing/hiding tiers and narrowing the search 
 // results via checkboxes) will work incorrectly. 
 function getTierName(lang, type) {
-  if (isIgnored(type)) {
-    return null;
-  }
-  
   // English UI text:
   // return decodeLang(lang) + " " + decodeType(type);
 

--- a/preprocessing/flex/flex_tier_names.js
+++ b/preprocessing/flex/flex_tier_names.js
@@ -1,0 +1,109 @@
+/* functions for naming Flex tiers */
+
+var isoDict = require('./iso_dict.json');
+
+function isIgnored(type) {
+  // Omit these tier types from the website, because they're ugly and mostly useless.
+  return (
+      type === "variantTypes" || // variantTypes indicates when a morpheme is a spelling variant, free variant, etc.
+      type === "hn" || // hn, "homophone number", indicates which of multiple look-alike morphemes it is.
+      type === "glsAppend" ||
+      type === "msa" // msa is the part of speech
+  );
+}
+
+// Must return a different string for each tier type in the corpus
+// so that tier names can be guaranteed to be unique.
+function decodeType(type) {
+  /*
+  // English UI text:
+    switch(type) {
+        case "txt": return "morpheme (text)";
+        case "cf": return "morpheme (citation form)";
+        case "gls": return "morpheme gloss"
+        case "msa": return "part of speech";
+    default: return type;
+    }
+  */
+
+  // Spanish UI text:
+  switch (type) {
+    case "txt":
+      return "Morfema (texto)";
+    case "cf":
+      return "Morfema (forma típico)";
+    case "gls":
+      return "Glosa de morfema";
+    case "msa":
+      return "Parte del habla";
+    case "words":
+      return "Palabra";
+    case "free":
+      return "Frase";
+    default:
+      return type;
+  }
+}
+
+// Must return a different string for each language in the corpus
+// so that tier names can be guaranteed to be unique.
+function decodeLang(lang) {
+
+  const desiredName = "Native name"; // or we might want to use "ISO language name"
+  const lcLang = lang.toLowerCase(); // ignore capitalization when decoding
+
+  // Override the usual iso-based decoding for some language codes
+  switch (lang) {
+    // case "flex-language-name-here": return "desired-decoded-name-here";
+    case "con-Latn-EC":
+      return "A'ingae (Borman)";
+    case "con-Latn-EC-x-dureno":
+      return "A'ingae (Dureno)";
+    case "defaultLang":
+      return "defaultLang";
+
+    // for Spanish UI text:
+    case "en":
+      return "Inglés";
+    default: // fall through
+  }
+
+  // if lang is an iso code, decode it
+  if (isoDict.hasOwnProperty(lcLang)) {
+    return isoDict[lcLang][desiredName];
+  }
+
+  // if lang starts with a (three-letter or two-letter) iso code, decode it
+  const firstThreeLetters = lcLang.substr(0, 3);
+  if (isoDict.hasOwnProperty(firstThreeLetters)) {
+    return isoDict[firstThreeLetters][desiredName];
+  }
+  const firstTwoLetters = lcLang.substr(0, 2);
+  if (isoDict.hasOwnProperty(firstTwoLetters)) {
+    return isoDict[firstTwoLetters][desiredName];
+  }
+
+  // as a last resort, return without decoding
+  return lang;
+}
+
+// if the tier is ignored, return null; else return its name
+// Note: LingView assumes that each tier has a unique name. 
+// If getTierName returns the same name for two different tiers in your corpus,
+// some features (specifically, showing/hiding tiers and narrowing the search 
+// results via checkboxes) will work incorrectly. 
+function getTierName(lang, type) {
+  if (isIgnored(type)) {
+    return null;
+  }
+  
+  // English UI text:
+  // return decodeLang(lang) + " " + decodeType(type);
+
+  // Spanish UI text:
+  return decodeType(type) + " " + decodeLang(lang).toLowerCase();
+}
+
+module.exports = {
+  getTierName: getTierName
+};

--- a/preprocessing/flex/flex_to_json.js
+++ b/preprocessing/flex/flex_to_json.js
@@ -31,16 +31,11 @@ function isSeparator(char) {
 // this word might come from a different language than what FLEx is trying 
 // to detect in this file, so this word should not be marked as a punctuation. 
 function isPunctuation(word) {
-  if (word.item[0].$.type === "punct")  {
-    const wordElement = word.item[0]._;
-    // The Regex checks if the word contains digits or alpha letters.
-    // This expression also includes special characters, such as accented letters
-    // or other letters not existent in English. 
-    if (wordElement && wordElement.match(/^[0-9a-zA-ZÀ-ÿ]+$/)) {
-      return false; 
-    } else {
-      return true; 
-    }
+  if (flexReader.getWordType(word) === "punct") {
+    const wordValue = flexReader.getWordValue(word);
+    // The Regex checks if the word contains any alphanumeric characters, 
+    // including special alphabetic characters such as accented letters. 
+    return wordValue == null || !wordValue.match(/^[0-9a-zA-ZÀ-ÿ]+$/);
   }
   return false; 
 }
@@ -194,7 +189,7 @@ function repackageMorphs(morphs, tierReg, startSlot) {
           }
           morphTokens[tierName][slotNum] = {
             "value": flexReader.getTierValue(tier),
-            "tier type": tier.$.type,
+            "tier type": flexReader.getTierType(tier),
             "part of speech": flexReader.getMorphPartOfSpeech(morph),
           };
         }
@@ -338,12 +333,11 @@ function getSentenceJson(sentence, speakerReg, tierReg, wordsTierID, hasTimestam
 // updates the index and story files for this interlinear text, 
 //   then executes the callback
 function preprocessText(jsonIn, jsonFilesDir, fileName, callback) {
-  let storyID = jsonIn.$.guid;
+  let storyID = flexReader.getDocumentID(jsonIn);
   
   let metadata = mediaFinder.improveFLExIndexData(fileName, storyID, jsonIn);
   const speakerReg = new speakerRegistry();
   metadata['speakers'] = speakerReg.getSpeakersList();
-  // updateIndex(metadata, "data/index.json", storyID);
 
   const jsonOut = {
     "metadata": metadata,

--- a/preprocessing/flex/flex_to_json.js
+++ b/preprocessing/flex/flex_to_json.js
@@ -317,11 +317,10 @@ function getSentenceJson(sentence, speakerReg, tierReg, wordsTierID, hasTimestam
 // jsonIn - the JSON parse of the FLEx interlinear-text
 // jsonFilesDir - the directory for the output file describing this interlinear text
 // fileName - the path to the FLEx file
-// isoDict - an object correlating languages with ISO codes
 // callback - the function that will execute when the preprocessText function completes
 // updates the index and story files for this interlinear text, 
 //   then executes the callback
-function preprocessText(jsonIn, jsonFilesDir, fileName, isoDict, callback) {
+function preprocessText(jsonIn, jsonFilesDir, fileName, callback) {
   let storyID = jsonIn.$.guid;
   
   let metadata = mediaFinder.improveFLExIndexData(fileName, storyID, jsonIn);
@@ -335,7 +334,7 @@ function preprocessText(jsonIn, jsonFilesDir, fileName, isoDict, callback) {
   };
 
   let textLang = flexReader.getDocumentSourceLang(jsonIn);
-  const tierReg = new tierRegistry(isoDict);
+  const tierReg = new tierRegistry();
   const wordsTierID = tierReg.maybeRegisterTier(textLang, "words", true);
 
   const hasTimestamps = flexReader.documentHasTimestamps(jsonIn);
@@ -368,18 +367,10 @@ function preprocessText(jsonIn, jsonFilesDir, fileName, isoDict, callback) {
 
 // xmlFilesDir - a directory containing zero or more FLEx files
 // jsonFilesDir - a directory for output files describing individual interlinear texts
-// isoFileName - the file address of a JSON object matching languages to their ISO codes
 // callback - the function that will execute when the preprocess_dir function completes
 // updates the index and story files for each interlinear text, 
 //   then executes the callback
-function preprocess_dir(xmlFilesDir, jsonFilesDir, isoFileName, callback) {
-  let isoDict = {};
-  try {
-    isoDict = JSON.parse(fs.readFileSync(isoFileName));
-  } catch (err) {
-    console.log("Unable to read ISO codes file. Error was " + err + " Proceeding anyway...");
-  }
-
+function preprocess_dir(xmlFilesDir, jsonFilesDir, callback) {
   const xmlFileNames = fs.readdirSync(xmlFilesDir).filter(f => f[0] !== '.'); // excludes hidden files
 
   // use this to wait for all preprocess calls to terminate before executing the callback
@@ -415,7 +406,7 @@ function preprocess_dir(xmlFilesDir, jsonFilesDir, isoFileName, callback) {
         };
         
         for (const text of texts) {
-          preprocessText(text, jsonFilesDir, xmlFileName, isoDict, singleTextCallback);
+          preprocessText(text, jsonFilesDir, xmlFileName, singleTextCallback);
         }
       });
     });

--- a/preprocessing/flex/read_flex.js
+++ b/preprocessing/flex/read_flex.js
@@ -1,6 +1,10 @@
 /* functions for accessing data within FLEx's Verifiable Generic XML and .flextext formats 
 (after they've been parsed to JSON): */
 
+function getDocumentID(doc) {
+  return doc.$.guid;
+}
+
 function getDocumentSourceLang(doc) {
   const firstSentence = getDocumentFirstSentence(doc);
   const firstWord = getSentenceWords(firstSentence)[0];
@@ -132,16 +136,20 @@ function getWordMorphs(word) {
   return word.morphemes[0].morph;
 }
 
-function getWordValue(word) {
-  return word.item[0]._;
-}
-
 function getWordLang(word) {
   return word.item[0].$.lang;
 }
 
+function getWordType(word) {
+  return word.item[0].$.type;
+}
+
+function getWordValue(word) {
+  return word.item[0]._;
+}
+
 function getMorphPartOfSpeech(morph) {
-  if (morph.$ == null) { // TODO I have no idea why this happens sometimes but it does
+  if (morph.$ == null) { // I have no idea why this happens sometimes but it does
     return null;
   }
   return morph.$.type;
@@ -172,6 +180,7 @@ function getFreeGlossValue(freeGloss) {
 }
 
 module.exports = {
+  getDocumentID: getDocumentID,
   getDocumentSourceLang: getDocumentSourceLang,
   documentHasTimestamps: documentHasTimestamps,
   getDocumentParagraphs: getDocumentParagraphs,
@@ -183,6 +192,7 @@ module.exports = {
   getSentenceSpeaker: getSentenceSpeaker,
   getSentenceWords: getSentenceWords,
   getWordMorphs: getWordMorphs,
+  getWordType: getWordType,
   getWordValue: getWordValue,
   getMorphPartOfSpeech: getMorphPartOfSpeech,
   getTiers: getTiers,

--- a/preprocessing/flex/read_flex.js
+++ b/preprocessing/flex/read_flex.js
@@ -140,10 +140,6 @@ function getWordLang(word) {
   return word.item[0].$.lang;
 }
 
-function getMorphTiers(morph) {
-  return morph.item;
-}
-
 function getMorphPartOfSpeech(morph) {
   if (morph.$ == null) { // TODO I have no idea why this happens sometimes but it does
     return null;
@@ -151,8 +147,24 @@ function getMorphPartOfSpeech(morph) {
   return morph.$.type;
 }
 
-function getMorphTierValue(morphTier) {
-  return morphTier._;
+function getTiers(morph) {
+  return morph.item;
+}
+
+function getTierLang(tier) {
+  return tier.$.lang;
+}
+
+function getTierType(tier) {
+  return tier.$.type;
+}
+
+function getTierValue(tier) {
+  return tier._;
+}
+
+function getFreeGlossLang(freeGloss) {
+  return freeGloss.$.lang
 }
 
 function getFreeGlossValue(freeGloss) {
@@ -172,8 +184,11 @@ module.exports = {
   getSentenceWords: getSentenceWords,
   getWordMorphs: getWordMorphs,
   getWordValue: getWordValue,
-  getMorphTiers: getMorphTiers,
   getMorphPartOfSpeech: getMorphPartOfSpeech,
-  getMorphTierValue: getMorphTierValue,
+  getTiers: getTiers,
+  getTierLang: getTierLang,
+  getTierType: getTierType,
+  getTierValue: getTierValue,
+  getFreeGlossLang: getFreeGlossLang,
   getFreeGlossValue: getFreeGlossValue,
 };

--- a/preprocessing/flex/tier_registry.js
+++ b/preprocessing/flex/tier_registry.js
@@ -8,13 +8,11 @@ class tierRegistry {
     return this.jsonTierIDs;
   }
 
-  // if this is a new, non-ignored tier, include it in metadata
-  maybeRegisterTier(tierName, isSubdivided) {
-    if (tierName != null) {
-      this.jsonTierIDs[tierName] = {
-        subdivided: isSubdivided,
-      };
-    }
+  // if this is a new tier, include it in metadata
+  registerTier(tierName, isSubdivided) {
+    this.jsonTierIDs[tierName] = {
+      subdivided: isSubdivided,
+    };
   }
 }
 

--- a/preprocessing/flex/tier_registry.js
+++ b/preprocessing/flex/tier_registry.js
@@ -1,109 +1,9 @@
-var isoDict = require('./iso_dict.json');
+var getTierName = require('./flex_tier_names.js').getTierName;
 
 class tierRegistry {
 
-  static isIgnored(type) {
-    // Omit these tier types from the website, as they're ugly and mostly useless.
-    return (
-        type === "variantTypes" || // variantTypes indicates when a morpheme is a spelling variant, free variant, etc.
-        type === "hn" || // hn, "homophone number", indicates which of multiple look-alike morphemes it is.
-        type === "glsAppend" ||
-        type === "msa" // msa is the part of speech
-    );
-  }
-
-  // Must return a different string for each tier type in the corpus
-  // so that tier names can be guaranteed to be unique.
-  static decodeType(type) {
-    /*
-    // English UI text:
-      switch(type) {
-          case "txt": return "morpheme (text)";
-          case "cf": return "morpheme (citation form)";
-          case "gls": return "morpheme gloss"
-          case "msa": return "part of speech";
-      default: return type;
-      }
-    */
-
-    // Spanish UI text:
-    switch (type) {
-      case "txt":
-        return "Morfema (texto)";
-      case "cf":
-        return "Morfema (forma típico)";
-      case "gls":
-        return "Glosa de morfema";
-      case "msa":
-        return "Parte del habla";
-      case "words":
-        return "Palabra";
-      case "free":
-        return "Frase";
-      default:
-        return type;
-    }
-  }
-
-  constructor(isoDict) {
+  constructor() {
     this.jsonTierIDs = {}; // format that should be written to file
-  }
-
-  // Must return a different string for each language in the corpus
-  // so that tier names can be guaranteed to be unique.
-  decodeLang(lang) {
-
-    const desiredName = "Native name"; // or we might want to use "ISO language name"
-    const lcLang = lang.toLowerCase(); // ignore capitalization when decoding
-
-    // Override the usual iso-based decoding for some language codes
-    switch (lang) {
-        // case "flex-language-name-here": return "desired-decoded-name-here";
-      case "con-Latn-EC":
-        return "A'ingae (Borman)";
-      case "con-Latn-EC-x-dureno":
-        return "A'ingae (Dureno)";
-      case "defaultLang":
-        return "defaultLang";
-
-        // for Spanish UI text:
-      case "en":
-        return "Inglés";
-
-      default: // fall through
-    }
-
-    // if lang is an iso code, decode it
-    if (isoDict.hasOwnProperty(lcLang)) {
-      return isoDict[lcLang][desiredName];
-    }
-
-    // if lang starts with a (three-letter or two-letter) iso code, decode it
-    const firstThreeLetters = lcLang.substr(0, 3);
-    if (isoDict.hasOwnProperty(firstThreeLetters)) {
-      return isoDict[firstThreeLetters][desiredName];
-    }
-    const firstTwoLetters = lcLang.substr(0, 2);
-    if (isoDict.hasOwnProperty(firstTwoLetters)) {
-      return isoDict[firstTwoLetters][desiredName];
-    }
-
-    // as a last resort, return without decoding
-    return lang;
-  }
-
-  // LingView assumes that each tier has a unique name. 
-  // If getTierName returns the same name for two different tiers in your corpus,
-  // some features (specifically, showing/hiding tiers and narrowing search 
-  // results via checkboxes) will work incorrectly. 
-  getTierName(lang, type) {
-    /*
-    // English UI text:
-      return decodeLang(lang) + " " + decodeType(type);
-    */
-
-    // Spanish UI text:
-    return tierRegistry.decodeType(type) + " " + this.decodeLang(lang).toLowerCase();
   }
 
   getTiersJson() {
@@ -113,13 +13,12 @@ class tierRegistry {
   // if this is a new, non-ignored tier, include it in metadata
   // if the tier is ignored, return null; else return its name
   maybeRegisterTier(lang, type, isSubdivided) {
-    if (tierRegistry.isIgnored(type)) {
-      return null;
+    const tierName = getTierName(lang, type)
+    if (tierName != null) {
+      this.jsonTierIDs[tierName] = {
+        subdivided: isSubdivided,
+      };
     }
-    const tierName = this.getTierName(lang, type)
-    this.jsonTierIDs[tierName] = {
-      subdivided: isSubdivided,
-    };
     return tierName;
   }
 }

--- a/preprocessing/flex/tier_registry.js
+++ b/preprocessing/flex/tier_registry.js
@@ -1,3 +1,5 @@
+var isoDict = require('./iso_dict.json');
+
 class tierRegistry {
 
   static isIgnored(type) {
@@ -45,7 +47,6 @@ class tierRegistry {
 
   constructor(isoDict) {
     this.jsonTierIDs = {}; // format that should be written to file
-    this.isoDict = isoDict;
   }
 
   // Must return a different string for each language in the corpus
@@ -73,18 +74,18 @@ class tierRegistry {
     }
 
     // if lang is an iso code, decode it
-    if (this.isoDict.hasOwnProperty(lcLang)) {
-      return this.isoDict[lcLang][desiredName];
+    if (isoDict.hasOwnProperty(lcLang)) {
+      return isoDict[lcLang][desiredName];
     }
 
     // if lang starts with a (three-letter or two-letter) iso code, decode it
     const firstThreeLetters = lcLang.substr(0, 3);
-    if (this.isoDict.hasOwnProperty(firstThreeLetters)) {
-      return this.isoDict[firstThreeLetters][desiredName];
+    if (isoDict.hasOwnProperty(firstThreeLetters)) {
+      return isoDict[firstThreeLetters][desiredName];
     }
     const firstTwoLetters = lcLang.substr(0, 2);
-    if (this.isoDict.hasOwnProperty(firstTwoLetters)) {
-      return this.isoDict[firstTwoLetters][desiredName];
+    if (isoDict.hasOwnProperty(firstTwoLetters)) {
+      return isoDict[firstTwoLetters][desiredName];
     }
 
     // as a last resort, return without decoding

--- a/preprocessing/flex/tier_registry.js
+++ b/preprocessing/flex/tier_registry.js
@@ -8,7 +8,7 @@ class tierRegistry {
     return this.tierIDs;
   }
 
-  // if this is a new tier, include it in metadata
+  // include this tier in the metadata
   registerTier(tierName, isSubdivided) {
     this.tierIDs[tierName] = {
       subdivided: isSubdivided,

--- a/preprocessing/flex/tier_registry.js
+++ b/preprocessing/flex/tier_registry.js
@@ -1,16 +1,16 @@
 class tierRegistry {
 
   constructor() {
-    this.jsonTierIDs = {}; // format that should be written to file
+    this.tierIDs = {}; // format that should be written to file
   }
 
   getTiersJson() {
-    return this.jsonTierIDs;
+    return this.tierIDs;
   }
 
   // if this is a new tier, include it in metadata
   registerTier(tierName, isSubdivided) {
-    this.jsonTierIDs[tierName] = {
+    this.tierIDs[tierName] = {
       subdivided: isSubdivided,
     };
   }

--- a/preprocessing/flex/tier_registry.js
+++ b/preprocessing/flex/tier_registry.js
@@ -1,5 +1,3 @@
-var getTierName = require('./flex_tier_names.js').getTierName;
-
 class tierRegistry {
 
   constructor() {
@@ -11,15 +9,12 @@ class tierRegistry {
   }
 
   // if this is a new, non-ignored tier, include it in metadata
-  // if the tier is ignored, return null; else return its name
-  maybeRegisterTier(lang, type, isSubdivided) {
-    const tierName = getTierName(lang, type)
+  maybeRegisterTier(tierName, isSubdivided) {
     if (tierName != null) {
       this.jsonTierIDs[tierName] = {
         subdivided: isSubdivided,
       };
     }
-    return tierName;
   }
 }
 

--- a/preprocessing/flex/tier_registry.js
+++ b/preprocessing/flex/tier_registry.js
@@ -1,3 +1,12 @@
+// This class exists to keep track of what all the tier names are
+// and which tiers are subdivided. 
+
+// Why? Because new tiers can be discovered from multiple functions in flex_to_json.js.
+// Without using this tierRegistry class, discovering a new tier would look like: 
+// tiersJson[tierName] = { subdivided: true };
+// That's fine and perhaps clearer, but it invites bugs. I previously wrote "subdivided"
+// in one place and "isSubdivided" in another, and didn't notice the problem for a while.
+
 class tierRegistry {
 
   constructor() {

--- a/preprocessing/rebuild.js
+++ b/preprocessing/rebuild.js
@@ -8,7 +8,6 @@ const buildSearch = require('./build_search').buildSearch;
 const flexFilesDir = "data/flex_files/";
 const elanFilesDir = "data/elan_files/";
 const jsonFilesDir = "data/json_files/";
-const isoFileName = "preprocessing/flex/iso_dict.json";
 const indexFileName = "data/index.json"; // stores metadata for all documents
 const searchIndexFileName = "data/search_index.json";
 
@@ -32,7 +31,7 @@ Promise.all([
   }),
   new Promise((resolve, reject) => {
     try {
-      flex.preprocess_dir(flexFilesDir, jsonFilesDir, isoFileName, resolve);
+      flex.preprocess_dir(flexFilesDir, jsonFilesDir, resolve);
     } catch (err) {
       reject(err);
     }


### PR DESCRIPTION
Adds more functions to flex_reader.js. Gets rid of maybeRegisterTier function. Moves the naming stuff (decodeLang, decodeType, getTierName) out of tier_registry.js into a new file flex_tier_names.js. We still have a tiny tier registry class. 