### PR TITLE
Fixing audio bar for video-only files

### DIFF
--- a/jsx/App/Stories/Story/Sidebar/Video.jsx
+++ b/jsx/App/Stories/Story/Sidebar/Video.jsx
@@ -17,11 +17,13 @@ export class Video extends React.Component {
 		$('#centerPanel').css('height', bodyHeight);
 		$("#centerPanel").css("width", "60%");
 
-		// Deactivate audio:
-		$('#footer').css('display', 'none');
-		$('#audio').removeAttr('ontimeupdate');
-		$('#audio').removeAttr('onclick');
-		$('#audio').attr('data-live', 'false');
+		// Deactivate audio (only if the audio footer exists)
+		if ($('#footer').length) {
+			$('#footer').css('display', 'none');
+			$('#audio').removeAttr('ontimeupdate');
+			$('#audio').removeAttr('onclick');
+			$('#audio').attr('data-live', 'false');
+		}
 
 		// Activate video:
 		$('#video').css('display', 'block'); // switched from 'inline' because it seemed unnecessary and allowed for flickering scrollbar glitch
@@ -33,12 +35,14 @@ export class Video extends React.Component {
 		var audio = document.getElementById('audio');
 		var video = document.getElementById('video');
 
-		if (!audio.paused) {
-			audio.pause();
-			video.play();
+		if (audio) {
+			if (!audio.paused) {
+				audio.pause();
+				video.play();
+			}
+			video.currentTime = audio.currentTime;
 		}
-
-		video.currentTime = audio.currentTime;
+		
 	}
 
 	static hide() {
@@ -58,19 +62,26 @@ export class Video extends React.Component {
 		$("#video").removeAttr("ontimeupdate");
 		$("#video").attr("data-live", "false");
 
-		// Activate audio:
-		$("#footer").css("display", "block");
-		$("#audio").attr("data-live", "true");
-		$("#audio").attr("ontimeupdate", "sync(this.currentTime)");
-		$("#audio").attr("onclick", "sync(this.currentTime)");
+		// Activate audio (only if the audio footer exists)
+		if ($('#footer').length) {
+			$("#footer").css("display", "block");
+			$("#audio").attr("data-live", "true");
+			$("#audio").attr("ontimeupdate", "sync(this.currentTime)");
+			$("#audio").attr("onclick", "sync(this.currentTime)");
+		}
 
 		// Match times:
 		var audio = document.getElementById("audio");
 		var video = document.getElementById("video");
-		if (!video.paused) {
-			video.pause();
-			audio.play();
+
+		if (audio) {
+			if (!video.paused) {
+				video.pause();
+				audio.play();
+			}
+			audio.currentTime = video.currentTime;
 		}
-		audio.currentTime = video.currentTime;
+		
+		
 	}
 }

--- a/jsx/App/Stories/Story/Story.jsx
+++ b/jsx/App/Stories/Story/Story.jsx
@@ -15,14 +15,11 @@ export class Story extends React.Component {
 
         setupTextSync();
 
-        // If there is a footer, i.e., if audio exists:
-        if ($('#footer').length !== 0) {
-            // If video exists:
-            if ($('#video').length !== 0) {
-                Video.show();
-            } else {
-                Video.hide();
-            }
+        // If video exists:
+        if ($('#video').length !== 0) {
+            Video.show();
+        } else {
+            Video.hide();
         }
     }
 
@@ -36,15 +33,14 @@ export class Story extends React.Component {
         const timed = (story['metadata']['timed']);
         let footer = null;
         if (timed) {
-            let audioFile;
             const media = story['metadata']['media'];
-            if (media.hasOwnProperty('audio')) {
-                audioFile = media['audio'];
+            if (media['audio'] != '') {
+                const audioFilePath = getMediaFilePath(media['audio']);
+                footer = <div id="footer"><audio data-live="true" controls controlsList="nodownload" id="audio" src={audioFilePath}/></div>;
             } else {
-                audioFile = media['video'];
+                const audioFilePath = getMediaFilePath(media['video']);
+                footer = <div hidden id="footer"><audio data-live="true" controls controlsList="nodownload" id="video" src={audioFilePath}/></div>;
             }
-            const audioFilePath = getMediaFilePath(audioFile);
-            footer = <div id="footer"><audio data-live="true" controls controlsList="nodownload" id="audio" src={audioFilePath}/></div>;
         }
         return (
             <div>


### PR DESCRIPTION
For files with only videos, unchecking the "Show Video" box will still make an audio bar at the bottom show up. This audio bar, however, will play the audio track of the video, and the times between the audio and video are synced. If the "Show Video" box is checked, the audio bar disappears, and the video is stopped at the timestamp where the audio was stopped.