### PR TITLE
Minimize rebuild logs

### DIFF
--- a/preprocessing/elan/elan_to_json.js
+++ b/preprocessing/elan/elan_to_json.js
@@ -530,8 +530,6 @@ function preprocessDir(eafFilesDir, jsonFilesDir, callback) {
 
   }
 
- 
-
 }
 
 module.exports = {

--- a/preprocessing/elan/elan_to_json.js
+++ b/preprocessing/elan/elan_to_json.js
@@ -485,17 +485,19 @@ function preprocessDir(eafFilesDir, jsonFilesDir, callback) {
   const status = {
     numJobs: eafFileNames.length,
     storyIDs: [],
+    storyID2Name: {}
   };
   if (eafFileNames.length === 0) {
-    callback(status.storyIDs);
+    callback(status);
   }
 
   const whenDone = function () {
     status.numJobs--;
     if (status.numJobs <= 0) {
-      callback(status.storyIDs);
+      callback(status);
     }
   };
+
 
   for (const eafFileName of eafFileNames) {
     const eafPath = eafFilesDir + eafFileName;
@@ -519,11 +521,17 @@ function preprocessDir(eafFilesDir, jsonFilesDir, callback) {
       parseXml(xmlData, function (err2, jsonData) {
         if (err2) throw err2;
         const adoc = jsonData.ANNOTATION_DOCUMENT;
-        status.storyIDs.push(elanReader.getDocID(adoc));
+        const storyID = elanReader.getDocID(adoc)
+        status.storyIDs.push(storyID);
+        status.storyID2Name[storyID] = eafFileName;
         preprocess(adoc, pfsxJson, jsonFilesDir, eafFileName, whenDone);
       });
     });
+
   }
+
+ 
+
 }
 
 module.exports = {

--- a/preprocessing/elan/elan_to_json.js
+++ b/preprocessing/elan/elan_to_json.js
@@ -498,7 +498,6 @@ function preprocessDir(eafFilesDir, jsonFilesDir, callback) {
   };
 
   for (const eafFileName of eafFileNames) {
-    console.log("Processing " + eafFileName);
     const eafPath = eafFilesDir + eafFileName;
     
     // parse .pfsx file, if found

--- a/preprocessing/find_media.js
+++ b/preprocessing/find_media.js
@@ -198,7 +198,7 @@ function getTitleFromFilename(filename) {
   return filename.substring(0, filename.lastIndexOf('.'));
 }
 
-function improveFLExIndexData(path, storyID, itext) {
+module.exports.improveFLExIndexData = function improveFLExIndexData(path, storyID, itext) {
   // I/P: path, a string
   //      itext, an interlinear text, e.g., jsonIn["document"]["interlinear-text"][0]
   // O/P: a JSON object, based on the index.json file and new metadata
@@ -288,7 +288,7 @@ function improveFLExIndexData(path, storyID, itext) {
   return metadata;
 }
 
-function improveElanIndexData(path, storyID, adoc) {
+module.exports.improveElanIndexData = function improveElanIndexData(path, storyID, adoc) {
   // I/P: path, a string
   //      storyID, a string
   //      adoc, an annotation document
@@ -350,11 +350,3 @@ function improveElanIndexData(path, storyID, adoc) {
 
   return metadata;
 }
-
-module.exports = {
-  verifyMedia: verifyMedia,
-  getMetadataFromIndex: getMetadataFromIndex,
-  getFilenameFromPath: getFilenameFromPath,
-  improveFLExIndexData: improveFLExIndexData,
-  improveElanIndexData: improveElanIndexData
-};

--- a/preprocessing/find_media.js
+++ b/preprocessing/find_media.js
@@ -20,7 +20,7 @@ function getFilenameFromPath(path) {
   // I/P: path, a string
   // O/P: the filename which occurs at the end of the path
   // Status: untested
-  const begin = path.lastIndexOf("/") + 1; // @Kalinda, this might fail on windows.
+  const begin = path.lastIndexOf("/") + 1;
   return path.substring(begin, path.length);
 }
 
@@ -85,7 +85,7 @@ function mediaSearch(filename, mediaType, mediaFiles, extensions) {
 		} else if (process.env.MISSING_MEDIA === 'link') {
 			mediaFile = remoteMedia.remoteUrl;
 		} else {
-			logRepetitiveError(`Error during media search: Unsupported value ${process.env.MISSING_MEDIA} for MISSING_MEDIA env variable.`);
+			console.warn(`Error during remote media search: Unsupported value ${process.env.MISSING_MEDIA} for MISSING_MEDIA env variable.`);
 		}
   }
 
@@ -100,7 +100,7 @@ function mediaSearch(filename, mediaType, mediaFiles, extensions) {
 
 function remoteMediaSearch(filenamesToTry) {
   if (!process.env.REMOTE_MEDIA_PATH || typeof process.env.REMOTE_MEDIA_PATH !== "string") {
-		logRepetitiveError(`Error while trying to locate media in remote storage: Unsupported value ${process.env.REMOTE_MEDIA_PATH} for REMOTE_MEDIA_PATH env variable.`);
+		console.warn(`Error while trying to locate media in remote storage: Unsupported value ${process.env.REMOTE_MEDIA_PATH} for REMOTE_MEDIA_PATH env variable.`);
   } else {
 		for (const filename of filenamesToTry) {
 			const remoteUrl = `${process.env.REMOTE_MEDIA_PATH.replace(/\/$/, '')}/${filename}`;
@@ -108,7 +108,7 @@ function remoteMediaSearch(filenamesToTry) {
 			try {
 				remoteUrlHeadSuccess = syncUrlExists(remoteUrl);
 			} catch (err) {
-				console.log(err);
+				console.warn(err);
 				continue;
 			}
 			if (remoteUrlHeadSuccess) {
@@ -117,19 +117,6 @@ function remoteMediaSearch(filenamesToTry) {
 		}
 	}
   return { filename: null, remoteUrl: null };
-}
-
-// Use this function for error messages that are likely to repeat, 
-// verbatim, multiple times during the rebuild process.
-// If possible, the errors will be saved until the end, 
-// and then each unique error will be printed exactly once. 
-// If that's not possible, the error will be printed immediately. 
-function logRepetitiveError(message) {
-	if (global.errorsToReportAtEnd) {
-		global.errorsToReportAtEnd.push(message);
-	} else {
-		console.warn(message);
-	}
 }
 
 const TARGET_MEDIA_FILE_EXTENSIONS = {

--- a/preprocessing/find_media.js
+++ b/preprocessing/find_media.js
@@ -61,7 +61,9 @@ function mediaSearch(filename, mediaType, mediaFiles, extensions) {
   // I/P: mediaFiles, a list of the media files that were linked in the ELAN or FLEx file
   // I/P: extensions, file extensions for media files, including the leading period (some iterable type, e.g. array or set)
   // O/P: the filename of the first valid media that was found, or null if none exists
-  console.log("🚨  WARN: " + filename + " is missing correctly linked " + mediaType + ". Attemping to find link...");
+	
+  process.stdout.write(filename + " is missing " + mediaType + "... "); // no newline
+	
   const shortFilename = filename.substring(0, filename.lastIndexOf('.'));
   const shortestFilename = filename.substring(0, filename.indexOf('.')); // more possible matches for .postflex.flextext files
   const filenamesToTryRaw = mediaFiles;
@@ -72,35 +74,25 @@ function mediaSearch(filename, mediaType, mediaFiles, extensions) {
 	const filenamesToTry = [...new Set(filenamesToTryRaw)]; // remove duplicates
   
   let mediaFile = findValidMedia(filenamesToTry);
-  if (mediaFile != null) {
-    console.log("🔍  SUCCESS: Found matching " + mediaType + ": " + mediaFile);
-  } else if (process.env.MISSING_MEDIA === 'ignore' || process.env.MISSING_MEDIA === 'link') {
-    console.log("🥽 Attempting to locate media in remote storage...");
+  if (mediaFile == null && process.env.MISSING_MEDIA != null) {
+    process.stdout.write("Looking in remote storage..."); // no newline
 
-    let remoteMedia, erred = false;
-    try {
-      remoteMedia = remoteMediaSearch(filenamesToTry);
-    } catch (err) {
-      console.log('Error while trying to locate media in remote storage:', err);
-      erred = true;
-    }
-
-    if (erred || remoteMedia.filename == null) {
-      console.log("👎 Failed to find requested media in remote storage for any of:", filenamesToTry);
-    } else if (process.env.MISSING_MEDIA === 'ignore') {
-      console.log("🥽 FOUND! Adding to list of required media.");
-      mediaFile = remoteMedia.filename;
-      if (global.missingMediaFiles) global.missingMediaFiles.push(`${remoteMedia.filename} (at ${remoteMedia.remoteUrl})`);
-    } else if (process.env.MISSING_MEDIA === 'link') {
-      console.log("🥽 FOUND! Linking to remote url...");
-      mediaFile = remoteMedia.remoteUrl;
-    }
-  } else if (typeof process.env.MISSING_MEDIA !== 'undefined') {
-    console.log("⚠ Unsupported value", process.env.MISSING_MEDIA, "for MISSING_MEDIA env variable.");
+    let remoteMedia = remoteMediaSearch(filenamesToTry);
+		
+		if (process.env.MISSING_MEDIA === 'ignore') {
+			mediaFile = remoteMedia.filename;
+			if (global.missingMediaFiles) global.missingMediaFiles.push(`${remoteMedia.filename} (at ${remoteMedia.remoteUrl})`);
+		} else if (process.env.MISSING_MEDIA === 'link') {
+			mediaFile = remoteMedia.remoteUrl;
+		} else {
+			logRepetitiveError(`Error during media search: Unsupported value ${process.env.MISSING_MEDIA} for MISSING_MEDIA env variable.`);
+		}
   }
 
-  if (mediaFile == null) {
-    console.log("❌  ERROR: Cannot find matching " + mediaType + " for " + shortFilename + ". ");
+  if (mediaFile != null) {
+		console.log("🥽 FOUND!");
+	} else {
+    console.log("❌ Not found.");
     if (global.missingMediaFiles) global.missingMediaFiles.push(filenamesToTry);
   }
   return mediaFile;
@@ -108,25 +100,36 @@ function mediaSearch(filename, mediaType, mediaFiles, extensions) {
 
 function remoteMediaSearch(filenamesToTry) {
   if (!process.env.REMOTE_MEDIA_PATH || typeof process.env.REMOTE_MEDIA_PATH !== "string") {
-    throw new Error(`Unsupported value ${process.env.REMOTE_MEDIA_PATH} for REMOTE_MEDIA_PATH env variable.`);
-  }
-
-  for (const filename of filenamesToTry) {
-    const remoteUrl = `${process.env.REMOTE_MEDIA_PATH.replace(/\/$/, '')}/${filename}`;
-    let remoteUrlHeadSuccess;
-    try {
-      remoteUrlHeadSuccess = syncUrlExists(remoteUrl);
-    } catch (err) {
-      console.log(err);
-      continue;
-    }
-    if (remoteUrlHeadSuccess) {
-      console.log('🔍 Found!', remoteUrl);
-      return { filename, remoteUrl };
-    }
-  }
-  console.log('❌ Could not find remotely!');
+		logRepetitiveError(`Error while trying to locate media in remote storage: Unsupported value ${process.env.REMOTE_MEDIA_PATH} for REMOTE_MEDIA_PATH env variable.`);
+  } else {
+		for (const filename of filenamesToTry) {
+			const remoteUrl = `${process.env.REMOTE_MEDIA_PATH.replace(/\/$/, '')}/${filename}`;
+			let remoteUrlHeadSuccess;
+			try {
+				remoteUrlHeadSuccess = syncUrlExists(remoteUrl);
+			} catch (err) {
+				console.log(err);
+				continue;
+			}
+			if (remoteUrlHeadSuccess) {
+				return { filename, remoteUrl };
+			}
+		}
+	}
   return { filename: null, remoteUrl: null };
+}
+
+// Use this function for error messages that are likely to repeat, 
+// verbatim, multiple times during the rebuild process.
+// If possible, the errors will be saved until the end, 
+// and then each unique error will be printed exactly once. 
+// If that's not possible, the error will be printed immediately. 
+function logRepetitiveError(message) {
+	if (global.errorsToReportAtEnd) {
+		global.errorsToReportAtEnd.push(message);
+	} else {
+		console.warn(message);
+	}
 }
 
 const TARGET_MEDIA_FILE_EXTENSIONS = {
@@ -190,7 +193,7 @@ function updateMediaMetadata(filename, storyID, metadata, linkedMediaPaths) {
   // Worst case scenario: no media
   if (!hasWorkingAudio && !hasWorkingVideo) {
     metadata['timed'] = false;
-    console.log("❌  ERROR: " + filename + " (unique ID: " + storyID + ") has no linked audio or video in the media_files directory. It will be processed as an untimed file and no audio, video, or time alignment will be displayed on the site.");
+    // console.log("❌ WARN: " + filename + " (unique ID: " + storyID + ") has no linked audio or video in the media_files directory. It will be processed as an untimed file and no audio, video, or time alignment will be displayed on the site.");
   }
 }
 
@@ -227,7 +230,6 @@ module.exports.improveFLExIndexData = function improveFLExIndexData(path, storyI
   if (metadata == null) { // file not in index previously
   
     let defaultTitle = getTitleFromFilename(getFilenameFromPath(path));
-    // console.log(32332, path, defaultTitle);
     // Uncomment the three lines below to use a particular language title 
     // (in this case "es", Spanish) as the main title for newly added documents. 
     // if (titles["es"] != null && titles["es"] != "") {

--- a/preprocessing/find_media.js
+++ b/preprocessing/find_media.js
@@ -61,9 +61,9 @@ function mediaSearch(filename, mediaType, mediaFiles, extensions) {
   // I/P: mediaFiles, a list of the media files that were linked in the ELAN or FLEx file
   // I/P: extensions, file extensions for media files, including the leading period (some iterable type, e.g. array or set)
   // O/P: the filename of the first valid media that was found, or null if none exists
-	
+  
   process.stdout.write(filename + " is missing " + mediaType + "... "); // no newline
-	
+  
   const shortFilename = filename.substring(0, filename.lastIndexOf('.'));
   const shortestFilename = filename.substring(0, filename.indexOf('.')); // more possible matches for .postflex.flextext files
   const filenamesToTryRaw = mediaFiles;
@@ -71,27 +71,27 @@ function mediaSearch(filename, mediaType, mediaFiles, extensions) {
     filenamesToTryRaw.push(shortFilename + extension);
     filenamesToTryRaw.push(shortestFilename + extension);
   }
-	const filenamesToTry = [...new Set(filenamesToTryRaw)]; // remove duplicates
+  const filenamesToTry = [...new Set(filenamesToTryRaw)]; // remove duplicates
   
   let mediaFile = findValidMedia(filenamesToTry);
   if (mediaFile == null && process.env.MISSING_MEDIA != null) {
     process.stdout.write("Looking in remote storage..."); // no newline
 
     let remoteMedia = remoteMediaSearch(filenamesToTry);
-		
-		if (process.env.MISSING_MEDIA === 'ignore') {
-			mediaFile = remoteMedia.filename;
-			if (global.missingMediaFiles) global.missingMediaFiles.push(`${remoteMedia.filename} (at ${remoteMedia.remoteUrl})`);
-		} else if (process.env.MISSING_MEDIA === 'link') {
-			mediaFile = remoteMedia.remoteUrl;
-		} else {
-			console.warn(`Error during remote media search: Unsupported value ${process.env.MISSING_MEDIA} for MISSING_MEDIA env variable.`);
-		}
+    
+    if (process.env.MISSING_MEDIA === 'ignore') {
+      mediaFile = remoteMedia.filename;
+      if (global.missingMediaFiles) global.missingMediaFiles.push(`${remoteMedia.filename} (at ${remoteMedia.remoteUrl})`);
+    } else if (process.env.MISSING_MEDIA === 'link') {
+      mediaFile = remoteMedia.remoteUrl;
+    } else {
+      console.warn(`Error during remote media search: Unsupported value ${process.env.MISSING_MEDIA} for MISSING_MEDIA env variable.`);
+    }
   }
 
   if (mediaFile != null) {
-		console.log("🥽 FOUND!");
-	} else {
+    console.log("🥽 FOUND!");
+  } else {
     console.log("❌ Not found.");
     if (global.missingMediaFiles) global.missingMediaFiles.push(filenamesToTry);
   }
@@ -100,22 +100,22 @@ function mediaSearch(filename, mediaType, mediaFiles, extensions) {
 
 function remoteMediaSearch(filenamesToTry) {
   if (!process.env.REMOTE_MEDIA_PATH || typeof process.env.REMOTE_MEDIA_PATH !== "string") {
-		console.warn(`Error while trying to locate media in remote storage: Unsupported value ${process.env.REMOTE_MEDIA_PATH} for REMOTE_MEDIA_PATH env variable.`);
+    console.warn(`Error while trying to locate media in remote storage: Unsupported value ${process.env.REMOTE_MEDIA_PATH} for REMOTE_MEDIA_PATH env variable.`);
   } else {
-		for (const filename of filenamesToTry) {
-			const remoteUrl = `${process.env.REMOTE_MEDIA_PATH.replace(/\/$/, '')}/${filename}`;
-			let remoteUrlHeadSuccess;
-			try {
-				remoteUrlHeadSuccess = syncUrlExists(remoteUrl);
-			} catch (err) {
-				console.warn(err);
-				continue;
-			}
-			if (remoteUrlHeadSuccess) {
-				return { filename, remoteUrl };
-			}
-		}
-	}
+    for (const filename of filenamesToTry) {
+      const remoteUrl = `${process.env.REMOTE_MEDIA_PATH.replace(/\/$/, '')}/${filename}`;
+      let remoteUrlHeadSuccess;
+      try {
+        remoteUrlHeadSuccess = syncUrlExists(remoteUrl);
+      } catch (err) {
+        console.warn(err);
+        continue;
+      }
+      if (remoteUrlHeadSuccess) {
+        return { filename, remoteUrl };
+      }
+    }
+  }
   return { filename: null, remoteUrl: null };
 }
 

--- a/preprocessing/find_media.js
+++ b/preprocessing/find_media.js
@@ -180,7 +180,6 @@ function updateMediaMetadata(filename, storyID, metadata, linkedMediaPaths) {
   // Worst case scenario: no media
   if (!hasWorkingAudio && !hasWorkingVideo) {
     metadata['timed'] = false;
-    // console.log("❌ WARN: " + filename + " (unique ID: " + storyID + ") has no linked audio or video in the media_files directory. It will be processed as an untimed file and no audio, video, or time alignment will be displayed on the site.");
   }
 }
 

--- a/preprocessing/flex/flex_to_json.js
+++ b/preprocessing/flex/flex_to_json.js
@@ -416,7 +416,6 @@ function preprocessDir(xmlFilesDir, jsonFilesDir, callback) {
   };
 
   for (const xmlFileName of xmlFileNames) {
-    console.log("Processing " + xmlFileName);
     const xmlPath = xmlFilesDir + xmlFileName;
     fs.readFile(xmlPath, function (err1, xmlData) {
       if (err1) throw err1;

--- a/preprocessing/flex/flex_to_json.js
+++ b/preprocessing/flex/flex_to_json.js
@@ -402,16 +402,17 @@ function preprocessDir(xmlFilesDir, jsonFilesDir, callback) {
   // use this to wait for all preprocess calls to terminate before executing the callback
   const status = {
     numJobs: xmlFileNames.length,
-    storyIDs: [],
+    storyIDs: [], 
+    storyID2Name: {}
   };
   if (xmlFileNames.length === 0) {
-    callback(status.storyIDs);
+    callback(status);
   }
 
   const whenDone = function () {
     status.numJobs--;
     if (status.numJobs <= 0) {
-      callback(status.storyIDs);
+      callback(status);
     }
   };
 
@@ -434,12 +435,16 @@ function preprocessDir(xmlFilesDir, jsonFilesDir, callback) {
         };
         
         for (const text of texts) {
-          status.storyIDs.push(flexReader.getDocumentID(text));
+          const storyID = flexReader.getDocumentID(text)
+          status.storyIDs.push(storyID);
+          status.storyID2Name[storyID] = xmlFileName;
           preprocessText(text, jsonFilesDir, xmlFileName, singleTextCallback);
         }
       });
     });
   }
+
+  
 }
 
 module.exports = {

--- a/preprocessing/flex/flex_to_json.js
+++ b/preprocessing/flex/flex_to_json.js
@@ -444,7 +444,6 @@ function preprocessDir(xmlFilesDir, jsonFilesDir, callback) {
     });
   }
 
-  
 }
 
 module.exports = {

--- a/preprocessing/rebuild.js
+++ b/preprocessing/rebuild.js
@@ -39,9 +39,14 @@ Promise.all([
 ])
 .then((results) => {
   console.log('Done preprocessing ELAN and FLEx!');
-	
-	const storyIDs = results[0].concat(results[1]);
-  console.log("The following stories were processed: " + storyIDs);
+  const resultsFromFlex = results[0];
+  const resultsFromElan = results[1];
+  const allStoryIDs2Name = Object.assign({}, resultsFromFlex.storyID2Name, resultsFromElan.storyID2Name);
+	//const storyIDs = results[0].concat(results[1]);
+  console.log("The following stories (IDs and filenames) were processed: "); 
+  console.log(allStoryIDs2Name);
+
+  const storyIDs = resultsFromFlex.storyIDs.concat(resultsFromElan.storyIDs);
 
 	if (global.missingMediaFiles.length > 0) {
 		console.log(global.missingMediaFiles.length, 'missing media files:', global.missingMediaFiles);

--- a/preprocessing/rebuild.js
+++ b/preprocessing/rebuild.js
@@ -13,9 +13,7 @@ const searchIndexFileName = "data/search_index.json";
 
 console.log("Converting all files to .JSON. The stories index (data/index.json), search index (data/search_index.json), and stories' metadata will also be updated during this process. Status messages will appear below:")
 
-// These global variables are updated by fetch_materials, then reported at the end
 global.missingMediaFiles = [];
-global.errorsToReportAtEnd = [];
 
 const indexPath = path.resolve(__dirname, '..', indexFileName);
 if (!fs.existsSync(indexPath)) {
@@ -47,11 +45,6 @@ Promise.all([
 
 	if (global.missingMediaFiles.length > 0) {
 		console.log(global.missingMediaFiles.length, 'missing media files:', global.missingMediaFiles);
-	}
-	
-	if (global.errorsToReportAtEnd.length > 0) {
-		console.log(global.errorsToReportAtEnd.length, 'additional errors occurred:');
-		console.log(global.missingMediaFiles.join('\n'));
 	}
 
   return storyIDs;

--- a/preprocessing/rebuild.js
+++ b/preprocessing/rebuild.js
@@ -13,7 +13,9 @@ const searchIndexFileName = "data/search_index.json";
 
 console.log("Converting all files to .JSON. The stories index (data/index.json), search index (data/search_index.json), and stories' metadata will also be updated during this process. Status messages will appear below:")
 
+// These global variables are updated by fetch_materials, then reported at the end
 global.missingMediaFiles = [];
+global.errorsToReportAtEnd = [];
 
 const indexPath = path.resolve(__dirname, '..', indexFileName);
 if (!fs.existsSync(indexPath)) {
@@ -39,11 +41,18 @@ Promise.all([
 ])
 .then((results) => {
   console.log('Done preprocessing ELAN and FLEx!');
-
-  const storyIDs = results[0].concat(results[1]);
+	
+	const storyIDs = results[0].concat(results[1]);
   console.log("The following stories were processed: " + storyIDs);
 
-  console.log(global.missingMediaFiles.length, 'Missing media files:', global.missingMediaFiles);
+	if (global.missingMediaFiles.length > 0) {
+		console.log(global.missingMediaFiles.length, 'missing media files:', global.missingMediaFiles);
+	}
+	
+	if (global.errorsToReportAtEnd.length > 0) {
+		console.log(global.errorsToReportAtEnd.length, 'additional errors occurred:');
+		console.log(global.missingMediaFiles.join('\n'));
+	}
 
   return storyIDs;
 })

--- a/preprocessing/rebuild.js
+++ b/preprocessing/rebuild.js
@@ -42,15 +42,15 @@ Promise.all([
   const resultsFromFlex = results[0];
   const resultsFromElan = results[1];
   const allStoryIDs2Name = Object.assign({}, resultsFromFlex.storyID2Name, resultsFromElan.storyID2Name);
-	//const storyIDs = results[0].concat(results[1]);
+  //const storyIDs = results[0].concat(results[1]);
   console.log("The following stories (IDs and filenames) were processed: "); 
   console.log(allStoryIDs2Name);
 
   const storyIDs = resultsFromFlex.storyIDs.concat(resultsFromElan.storyIDs);
 
-	if (global.missingMediaFiles.length > 0) {
-		console.log(global.missingMediaFiles.length, 'missing media files:', global.missingMediaFiles);
-	}
+  if (global.missingMediaFiles.length > 0) {
+    console.log(global.missingMediaFiles.length, 'missing media files:', global.missingMediaFiles);
+  }
 
   return storyIDs;
 })


### PR DESCRIPTION
- Don't say "Processing <filename>"
- Shorten the warning and error messages when looking for a media file
- Output a dictionary-formatted log with the ID and filename of each of the processed stories