### PR TITLE
Combine setupTextSync and setupYoutube into one sequence of function calls

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,6 @@
       firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
 
       var youTubeIframeAPIReady = false;
-      //var player;
       function onYouTubeIframeAPIReady() {
         youTubeIframeAPIReady = true;
       }

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
       firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
 
       var youTubeIframeAPIReady = false;
-      var player;
+      //var player;
       function onYouTubeIframeAPIReady() {
         youTubeIframeAPIReady = true;
       }

--- a/jsx/App/Stories/Story/Story.jsx
+++ b/jsx/App/Stories/Story/Story.jsx
@@ -1,7 +1,7 @@
 import { Sidebar } from './Sidebar/Sidebar.jsx';
 import { CenterPanel } from './Display/CenterPanel.jsx';
 import { Video } from './Sidebar/Video.jsx';
-import { setupTextSync, setupYoutube } from './lib/txt_sync';
+import { setupYoutubeAndTextSync } from './lib/txt_sync';
 import { Loader } from '../Loader.jsx';
 
 export class Story extends React.Component {
@@ -13,9 +13,8 @@ export class Story extends React.Component {
         const storyJSON = await import(`~./data/json_files/${this.props.storyID}.json`);
         this.setState({ story: storyJSON.default });
 
-        setupYoutube();
-        setupTextSync();
-
+        setupYoutubeAndTextSync();
+        
         // If video exists:
         if ($('#video').length !== 0) {
             Video.show();

--- a/jsx/App/Stories/Story/lib/txt_sync.js
+++ b/jsx/App/Stories/Story/lib/txt_sync.js
@@ -185,7 +185,7 @@ export function setupYoutubeAndTextSync() {
         player = new window.YT.Player("video", {
             height: "270",
             width: "480",
-            videoId: youtubeID,
+            videoId: youtubeID
         });
         player.addEventListener('onReady', onPlayerReady);
     });

--- a/jsx/App/Stories/Story/lib/txt_sync.js
+++ b/jsx/App/Stories/Story/lib/txt_sync.js
@@ -1,9 +1,9 @@
 // Based on http://community.village.virginia.edu/etst/
 
+let player; // object for Youtube player
 
-let player; 
-
-export function setupTextSync() {
+/* Sets up syncing between AV file and text scrolling and highlighting. */
+function setupTextSync() {
 
     // "media" is undefined if there are no AV files associated with the current text. 
     const media = document.querySelectorAll("[data-live='true']")[0];
@@ -97,11 +97,11 @@ export function setupTextSync() {
     // This function adjusts the AV file(s)' timestamp according to the 
     // selected sentence's URL
     function setMediaCurrentTime(timestampMilliseconds) {
-        const youtubeVideo = $("[is-youtube='true']").get(0);
-        if (youtubeVideo) {
+        if (getYoutubeMedia()) {
             // The timestamp unit on Youtube videos is seconds,
             // so need to divide t, which is in ms, by 1000.
             player.seekTo(timestampMilliseconds / 1000);
+            player.playVideo();
         } else {
             const media = $("[data-live='true']").get(0);
             if (media) {
@@ -146,34 +146,51 @@ export function setupTextSync() {
                 scrollIntoViewIfNeeded($("#current")[0]);
             } 
         }
+
+        // Call the sync function on the Youtube video every 0.1 second.
+        // This ensures that the corresponding text is highlighted when
+        // the text's timestamp matches the video's timestamp. 
+        if (getYoutubeMedia()) {
+            setInterval(function(){
+                const currentTime = player.playerInfo.currentTime;
+                sync(currentTime);
+            }, 100);
+        }
+        
     });
   
 }
 
-
-export function setupYoutube() {
-
+// Returns the element on the page with the tag "is-youtube=true".
+function getYoutubeMedia() {
     const youtubeMedia = document.querySelectorAll("[is-youtube='true']")[0];
+    return youtubeMedia;
+}
+
+/* First sets up Youtube player and related functionality, if the story has a 
+* Youtube video. When the YT player is ready, or if the story does
+* not require Youtube setup, calls setupTextSync.
+*/
+export function setupYoutubeAndTextSync() {
+    const youtubeMedia = getYoutubeMedia();
     if (!youtubeMedia) {
+        setupTextSync();
         return; 
     }
 
     const youtubeID = youtubeMedia.getAttribute('youtube-id');
-
+    
     // Initialize YouTube player: 
     window.YT.ready(function() {
         player = new window.YT.Player("video", {
             height: "270",
             width: "480",
-            videoId: youtubeID
+            videoId: youtubeID,
         });
+        player.addEventListener('onReady', onPlayerReady);
     });
 
-    // Call the sync function on the Youtube video every 0.1 second.
-    // This ensures that the corresponding text is highlighted when
-    // the text's timestamp matches the video's timestamp. 
-    setInterval(function(){
-        const currentTime = player.playerInfo.currentTime;
-        sync(currentTime);
-      }, 100);
+    function onPlayerReady(event) {
+        setupTextSync();
+    }
 }


### PR DESCRIPTION
I moved the call to ```setupTextSync``` to inside setupYoutube (now ```setupYoutubeAndTextSync```) so that the YouTube player is initialized before any text syncing feature attempts to happen. Similarly, in ```Story.jsx```, I only make one call to ```setupYoutubeAndTextSync``` now. This ensures that, for a story with a YouTube video, any call to the YouTube ```player``` is not undefined in setupTextSync.

This change also enables the sentence URL linking feature that was previously broken for stories with YouTube videos. (trying to solve #78)