### PR TITLE
Change LaTeX formatter tier selection buttons into grid-view

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -205,8 +205,23 @@ td {
 	padding-top: 5%; 
 }
 
-.tierSelectionRow {
-	padding-bottom: 12px;
+.tiersHeaderSection, .tierSelectionRow {
+	display: grid;
+	grid-template-columns: 1fr 8fr;
+	justify-self: center;
+	padding: 5px;
+}
+
+.tiersHeader, .tierSelectionRowButtonSection {
+	display: flex;
+	flex-direction: row;
+	margin: 5px;
+	justify-content: space-evenly;
+}
+
+.tierHeaderName {
+	margin: 5px;
+	width: 100%;
 }
 
 .latexResultContainer {

--- a/jsx/App/Stories/Story/Display/Latex/TierButtonList.jsx
+++ b/jsx/App/Stories/Story/Display/Latex/TierButtonList.jsx
@@ -10,43 +10,27 @@ export const TierButtonList = ({ sentenceId, tierNames, latexSectionId, latexSec
   return (
     <div className="tierSelectionRow">
       <b><TranslatableText dictionary={latexSectionName} /></b>
-      <TierRadioButtons sentenceId={sentenceId} tierNames={tierNames} latexSectionId={latexSectionId} latexSectionName={latexSectionName} />
+      <div className="tierSelectionRowButtonSection">
+        {tierNames.map((tierName, i) => {
+          return (<TierRadioButton 
+                    sentenceId={sentenceId}
+                    escapedTierName={htmlEscape(tierName)} 
+                    latexSectionId={latexSectionId} 
+                    buttonId={`button-${sentenceId}-${htmlEscape(tierName)}-for-${latexSectionId}`} 
+                    isChecked={i == 0} 
+                  />);
+        })}
+      </div>
+      
     </div>
   );
 };
 
-const TierRadioButtons = ({ sentenceId, tierNames, latexSectionId, latexSectionName }) => {
-  const children = [];
-  
-  // Iterate through tier names and create a list of radio buttons corresponding to each tier. 
-  for (let i = 0; i < tierNames.length; i++) {
-    // Call escape function on tier names so that special characters can be used as HTML property names.
-    const tierName = tierNames[i];
-    const escapedTierName = htmlEscape(tierName);
-    
-    const buttonId = `button-${sentenceId}-${escapedTierName}-for-${latexSectionId}`;
-    
-    children.push(
-      <TierRadioButton 
-        sentenceId={sentenceId}
-        escapedTierName={escapedTierName} 
-        latexSectionId={latexSectionId} 
-        buttonId={buttonId} 
-        isChecked={i == 0} 
-      />
-    );
-    children.push(
-      <TierRadioButtonLabel 
-        tierName={tierName} 
-        buttonId={buttonId} 
-      />
-    );
-  }
-  
-  return (<div>{children}</div>);
-};
-
-const TierRadioButton = ({ sentenceId, escapedTierName, latexSectionId, buttonId, isChecked }) => {
+const TierRadioButton = ({ sentenceId, 
+                           escapedTierName, 
+                           latexSectionId, 
+                           buttonId, 
+                           isChecked }) => {
   const groupName = `button-${sentenceId}-for-${latexSectionId}`;
   
   return (
@@ -58,8 +42,4 @@ const TierRadioButton = ({ sentenceId, escapedTierName, latexSectionId, buttonId
       defaultChecked={isChecked}
     />
   );
-};
-
-const TierRadioButtonLabel = ({ tierName, buttonId }) => {
-  return (<label for={buttonId}>{tierName}</label>);
 };

--- a/jsx/App/Stories/Story/Display/Latex/TierSelectionWindow.jsx
+++ b/jsx/App/Stories/Story/Display/Latex/TierSelectionWindow.jsx
@@ -50,6 +50,20 @@ export default class TierSelectionWindow extends React.Component {
     return tierNames;
   }
 
+  /* Create the header containing all the tier names in one row. */
+  createTiersHeader() {
+    let tiers = this.getTierNames().map((tierName) => (
+      <div className="tierHeaderName">{tierName}</div>
+    ));
+    // Add an empty element in the beginning so that each header is aligned with
+    // the column of radio buttons appearing underneath it. 
+    // The left-most column in the entire selection grid should be the tier name column.
+    return <div className="tiersHeaderSection">
+            <div className="fillerSlot"></div>
+            <div className="tiersHeader">{tiers}</div>
+           </div>;
+  }
+
   /* 
     Displays the tier selection window where the user tells LingView 
     which tier corresponds to which section in the LaTeX example through
@@ -57,12 +71,10 @@ export default class TierSelectionWindow extends React.Component {
   */
   getTierSelectionFormChildren() {
     const children = [];
-    
     // For each LaTeX section that needs to be formatted, create a list of radio buttons
     // so that the user can select which tier is matched to this section.
-    let tierNames = this.getTierNames();
     for (let [latexSectionId, latexSectionName] of Object.entries(latexSectionIdsToNames)) { 
-      children.push(<TierButtonList sentenceId={this.props.sentenceId} tierNames={tierNames} latexSectionId={latexSectionId} latexSectionName={latexSectionName} />);
+      children.push(<TierButtonList sentenceId={this.props.sentenceId} tierNames={this.getTierNames()} latexSectionId={latexSectionId} latexSectionName={latexSectionName} />);
     }
     
     return children;
@@ -105,7 +117,10 @@ export default class TierSelectionWindow extends React.Component {
           <div className="tierSelectionWrapper">
             <form className="tierSelectionForm" id={this.props.sentenceId}>
               <p><TranslatableText dictionary={latexSelectTiersPromptText} /></p>
-              {this.getTierSelectionFormChildren()}
+              <div className="tierSelectionGrid">
+                {this.createTiersHeader()}
+                {this.getTierSelectionFormChildren()}
+              </div>
             </form>
             <button class="confirmButton" onClick={this.handleConfirmButtonClick}>
               <TranslatableText dictionary={tierSelectionConfirmButtonText} />


### PR DESCRIPTION
The tier selection window now looks like this, which is less cluttered than the previous version: 
![Screen Shot 2021-11-30 at 10 03 08](https://user-images.githubusercontent.com/46336328/144072224-f4bba9da-3543-4365-89a1-ef253e0b14dd.png)

