### PR TITLE
Add a close button to LaTeX formatter

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -198,7 +198,7 @@ td {
 }
 
 .tierSelectionSection {
-	background : rgb(215, 233, 252);
+	background : rgb(212, 234, 247);
 	padding-bottom: 5%;
 	padding-left: 5%;
 	padding-right: 5%;
@@ -226,6 +226,28 @@ td {
 
 .latexResultContainer {
 	overflow-x: scroll;
+}
+
+#latexFormatterConfirmButton,   
+#latexFormatterCloseButton {
+	background-color: white;
+	border-radius: 4px;
+	transition-duration: 0.2s;
+}
+
+#latexFormatterConfirmButton:hover {
+	background-color: #4CAF50;
+	color: white;
+}
+  
+#latexFormatterCloseButton {
+	margin-bottom: 3%;
+	margin-top: 3%;
+}
+
+#latexFormatterCloseButton:hover {
+	background-color: #f44336;
+	color: white;
 }
 
 span.timeStamp {

--- a/jsx/App/Stories/Story/Display/Latex/LatexResultWindow.jsx
+++ b/jsx/App/Stories/Story/Display/Latex/LatexResultWindow.jsx
@@ -1,12 +1,5 @@
 import React from 'react';
 import { LatexResultContainer } from "./LatexResultContainer.jsx";
-import { TranslatableText } from "~./jsx/App/locale/TranslatableText.jsx";
-import { 
-  latexSentenceTierName, 
-  latexMorphemesTierName, 
-  latexMorphemeTranslationsTierName, 
-  latexSentenceTranslationsTierName,
-} from "~./jsx/App/locale/LocaleConstants.jsx";
 var htmlEscape = require("html-es6cape");
 
 /*

--- a/jsx/App/Stories/Story/Display/Latex/TierSelectionWindow.jsx
+++ b/jsx/App/Stories/Story/Display/Latex/TierSelectionWindow.jsx
@@ -9,9 +9,8 @@ import {
   latexMorphemeTranslationsTierName, 
   latexSentenceTranslationsTierName,
   tierSelectionConfirmButtonText,
+  latexCloseButtonText
 } from "~./jsx/App/locale/LocaleConstants.jsx";
-
-const htmlEscape = require("html-es6cape");
 
 // Each ID is a stable identifier that doesn't depend on the current language.
 // The names are textTranslations to show to the user. 
@@ -34,11 +33,13 @@ export default class TierSelectionWindow extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      buttonClicked : false,
+      latexButtonClicked : false,
       tierMap : {}
     }
-
+    // Create and ID for this sentence's LaTeX window. 
+    this.latexResultWindowId = `latex-result-window-${this.props.sentenceId}`; 
     this.handleConfirmButtonClick = this.handleConfirmButtonClick.bind(this);
+    this.closeFormatter = this.closeFormatter.bind(this);
   }
 
   /* Retrieves all the tier names for this story. */
@@ -105,10 +106,16 @@ export default class TierSelectionWindow extends React.Component {
     // Add the tierMap to the state so that this object can be passed
     // on to the result window.
     this.setState({
-      buttonClicked : true,
+      latexButtonClicked : true,
       tierMap : tierMap
     }); 
 
+  }
+
+  /* Reload the page when the close button is clicked. */
+  closeFormatter(e) {
+    e.preventDefault();
+    window.location.reload();
   }
 
   render() {
@@ -122,17 +129,22 @@ export default class TierSelectionWindow extends React.Component {
                 {this.getTierSelectionFormChildren()}
               </div>
             </form>
-            <button class="confirmButton" onClick={this.handleConfirmButtonClick}>
+            <button id="latexFormatterConfirmButton" 
+                    onClick={this.handleConfirmButtonClick}>
               <TranslatableText dictionary={tierSelectionConfirmButtonText} />
             </button>
           </div>
-          
-          {this.state.buttonClicked ? 
+          {this.state.latexButtonClicked ? 
             <LatexResultWindow 
+              id={this.latexResultWindowId}
               sentenceId={this.props.sentenceId} 
               tierMap={this.state.tierMap} 
               sentence={this.props.sentence}
               metadata={this.props.metadata}/> : null}
+          <button id="latexFormatterCloseButton"
+                  onClick={this.closeFormatter}>
+            <TranslatableText dictionary={latexCloseButtonText} />
+          </button>
       </div>
     );
   }; 

--- a/jsx/App/Stories/Story/Display/LatexButton.jsx
+++ b/jsx/App/Stories/Story/Display/LatexButton.jsx
@@ -20,7 +20,9 @@ export class LatexButton extends React.Component {
     /* Updates the flag when button is clicked so that the tier selection component gets rendered. */
     handleClick(e) {
         e.preventDefault();
-
+        // Do a click action on the sentence's time stamp so that this sentence
+        // is highlighted and the site's URL changes to this sentence's URL.
+        document.getElementById(this.props.sentenceMinStart).click();
         this.setState({
             buttonClicked : true
         });

--- a/jsx/App/Stories/Story/Display/Timed.jsx
+++ b/jsx/App/Stories/Story/Display/Timed.jsx
@@ -16,7 +16,7 @@ function LabeledSentence({ sentence }) {
 	);
 }
 
-function TimeBlock({ sentences, metadata }) {
+function TimeBlock({ sentences, metadata, minStart }) {
 	// I/P: sentences, a list of sentences with the same start time
 	// O/P: div containing multiple LabeledSentences
 	// Status: tested, working
@@ -26,7 +26,7 @@ function TimeBlock({ sentences, metadata }) {
 	// as well as a LaTeX button for this block.
 	for (const sentence of sentences) {
 		output.push(<LabeledSentence key={id.generate()} sentence={sentence} />);
-		output.push(<LatexButton sentence={sentence} metadata={metadata}/>);
+		output.push(<LatexButton sentenceMinStart={minStart} sentence={sentence} metadata={metadata}/>);
 	}
 	return <div className="timeBlock">{output}</div>;
 }
@@ -65,7 +65,7 @@ function LabeledTimeBlock({ sentences, timestamp, metadata }) {
 			<span className="timeStampContainer timeStamp" id={minStart} data-start_time={minStart}>
 				{timestamp}
 			</span>	
-			<TimeBlock sentences={sentences} metadata={metadata}/>
+			<TimeBlock sentences={sentences} metadata={metadata} minStart={minStart}/>
 		</div>
 	);
 }

--- a/jsx/App/locale/LocaleConstants.jsx
+++ b/jsx/App/locale/LocaleConstants.jsx
@@ -177,9 +177,9 @@ export const latexMorphemesTierName = {
 };
 
 export const latexMorphemeTranslationsTierName = {
-	[ENGLISH] : "morpheme translations",
-	[ESPANOL] : "morfemas traducidos",
-	[FRANCAIS] : "morphèmes traduits",
+	[ENGLISH] : "morpheme glosses",
+	[ESPANOL] : "glosas de morfemas",
+	[FRANCAIS] : "gloses de morphèmes",
 };
 
 export const latexSentenceTranslationsTierName = {

--- a/jsx/App/locale/LocaleConstants.jsx
+++ b/jsx/App/locale/LocaleConstants.jsx
@@ -195,6 +195,13 @@ export const tierSelectionConfirmButtonText = {
   [FRANCAIS] : "Confirmer",
 };
 
+// Text on the LaTeX formatter close button
+export const latexCloseButtonText = {
+  [ENGLISH] : "Close",
+  [ESPANOL] : "Cerrar",
+  [FRANCAIS] : "Fermer",
+};
+
 export const latexStoryTitleText = {
   [ENGLISH] : "Story title:",
   [ESPANOL] : "Título de la historia:",


### PR DESCRIPTION
This close button, which turns red when the cursor hovers over it, will reload the page and effectively closing the formatter section. 

An additional update to the "LaTeX" button: when it is clicked, the current sentence gets highlighted and the site's URL changes to this sentence's URL (and the a/v files also sync to the timestamp). This way, after closing this sentence's formatter section, the page will scroll to this sentence after reloading. 