### PR TITLE
Add sentenceMinStart props to the LaTeX button in Untimed sentence blocks 

### DIFF
--- a/jsx/App/Stories/Story/Display/Untimed.jsx
+++ b/jsx/App/Stories/Story/Display/Untimed.jsx
@@ -5,11 +5,11 @@ import { LatexButton } from './LatexButton.jsx';
 function UntimedBlock({ sentence, sentenceId, metadata }) {
 	return (
 		<div className="untimedBlock">
-			<span className="timeStampContainer timeStamp" data-sentence_id={sentenceId}>
+			<span className="timeStampContainer timeStamp" id={sentenceId} data-sentence_id={sentenceId}>
 				{sentenceId}
 			</span>
 			<Sentence sentence={sentence} />
-			<LatexButton sentence={sentence} metadata={metadata}/>
+			<LatexButton sentenceMinStart={sentenceId} sentence={sentence} metadata={metadata}/>
 		</div>
 	);
 }


### PR DESCRIPTION
This prop is added in the last PR for only the Timed blocks, but the untimed ones need this too in order for the LaTeX button to highlight the current sentence when clicked. 