### PR TITLE
Open search result's URL in a new tab

### DIFF
--- a/jsx/App/Stories/Story/Display/Sentence.jsx
+++ b/jsx/App/Stories/Story/Display/Sentence.jsx
@@ -106,5 +106,5 @@ export function SearchSentence({ sentence }) {
 	url += ("story/" + sentence["story ID"] + "?" + query_index);
 
     // hacky way to introduce a line break (extra <tr> of height 12px)
-	return <div className="searchSentence"><table className="gloss"><thead><tr><td><b> <TranslatableText dictionary={storySearchText} /></b>: {title}</td></tr><tr style={{"height": "12px"}}></tr></thead><tbody>{rowList}</tbody></table><div class="storyLink"><a href={url}><TranslatableText dictionary={storySearchViewStoryText} /></a></div></div>;
+	return <div className="searchSentence"><table className="gloss"><thead><tr><td><b> <TranslatableText dictionary={storySearchText} /></b>: {title}</td></tr><tr style={{"height": "12px"}}></tr></thead><tbody>{rowList}</tbody></table><div class="storyLink"><a target="_blank" href={url}><TranslatableText dictionary={storySearchViewStoryText} /></a></div></div>;
 }


### PR DESCRIPTION
Currently, when on the search page, clicking on a search results' URL will open that URL in the same window, which means that if the user wants to click on the back button to go back to the page with all the search results, the search results will disappear. 

I added the ```target="_blank"``` tag in the search result's href element, so now when clicking on a search result, the result is opened in a new window, and the old search results are preserved in the old window. 