### PR TITLE
Fix trailing dash detection for FLEx formatting

### DIFF
--- a/preprocessing/flex/flex_to_json.js
+++ b/preprocessing/flex/flex_to_json.js
@@ -87,7 +87,7 @@ function concatMorphs(morphsThisTier, wordStartSlot, wordEndSlot) {
     if (maybeAddCompoundSeparator && !isSeparator(nextValue.substring(0, 1))) {
       wordMorphsText += '+';
     }
-    if (!isSeparator(nextValue.substring(-1))) {
+    if (!isSeparator(nextValue.slice(-1))) {
       maybeAddCompoundSeparator = true;
     }
 


### PR DESCRIPTION
The line for determining whether there's a trailing dash was looking at the entire morpheme rather than just the last character of the morph, so it was always returning false.