### PR TITLE
handle missing text definitions

### DIFF
--- a/jsx/App/locale/TranslatableText.jsx
+++ b/jsx/App/locale/TranslatableText.jsx
@@ -12,6 +12,21 @@ import { LocaleContext } from "./LocaleContext.jsx"
 export const TranslatableText = ({ dictionary }) => {
   const { locale } = useContext(LocaleContext);
 
+  if (!dictionary) {
+    // If dictionary is undefined due to a bug,
+    // don't break the entire site, just log an error and move on.
+    // Without this, we would throw "Uncaught TypeError: dictionary is undefined"
+    // and the entire LingView site would be replaced with a blank white screen.
+    console.error(
+      `[TranslatableText] Error: dictionary is undefined.`
+    );
+
+    // To debug, you can return a string, then look for that string on your LingView site:
+    // return "This TranslatableText is undefined.";
+
+    return null;
+  }
+
   // Display text in the currently selected language, if it exists
   if (dictionary[locale]) {
     return dictionary[locale];


### PR DESCRIPTION
TranslatableText should check if its dictionary is undefined, and if so, log an error message without breaking the entire site. It already does this if the dictionary doesn't contain the preferred language.

The Cofan site was broken (blank screen, "Uncaught TypeError: dictionary is undefined" error message in the console) due to a missing definition for footerText, and it was very hard for us to identify the cause and unbreak the site. With this fix, missing dictionaries won't break the entire site, and they will also be easier to debug. 

### Manual testing
- [x] Build and open index.html locally. Click around a bit. Make sure there are no console errors. 
- [x] Switch languages within the site (English to Spanish). Make sure the site's UI text updates correctly. 
- [x] Temporarily delete the `footerText` definition from `LocaleConstants.tsx`, then rebuild the site. Confirm that the site works, but the footer has less text in it and the error is logged in the console.
- [x] Temporarily uncomment line 25, rebuild the site, and confirm the placeholder text appears in the footer of the site. 